### PR TITLE
For ubuntu users, added apt-get commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ add install\cgnslib-[ver]\release\bin and install\hdf5-[ver]\release\bin to "Pat
 * Qt 5.5 available from http://download.qt.io/archive/qt/5.5/5.5.1/qt-opensource-linux-x64-5.5.1.run
 
 ```
+sudo apt-get install gcc g++ cmake wget libxt-dev qt5-default qttools5-dev libqt5svg5-dev
 git clone https://github.com/i-RIC/iricdev.git iricdev_gcc
 cd iricdev_gcc
 ./download.sh


### PR DESCRIPTION
Hi Scott,

I've added a line to execute apt-get command to install needed softwares.

I've tested your master branch. I have some suggestions:

- libxt-dev is needed for building VTK
- qt5-default is needed for building VTK and iRIC
- qttools5-dev is needed for building VTK, because VTK needs qt-designer
- libqt5svg5-dev is needed for building qwt

I guess it is possible to do similar improvements for Scientific Linux release 6.7.