### PR TITLE
Added gfortran and m4 as package to be installed to ubuntu 16.04.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ add install\cgnslib-[ver]\release\bin and install\hdf5-[ver]\release\bin to "Pat
 * Qt 5.5 available from http://download.qt.io/archive/qt/5.5/5.5.1/qt-opensource-linux-x64-5.5.1.run
 
 ```
-sudo apt-get install gcc g++ cmake wget libxt-dev qt5-default qttools5-dev libqt5svg5-dev
+sudo apt-get install gcc g++ gfortran cmake wget libxt-dev qt5-default qttools5-dev libqt5svg5-dev m4
 git clone https://github.com/i-RIC/iricdev.git iricdev_gcc
 cd iricdev_gcc
 ./download.sh


### PR DESCRIPTION
I added gfortran and m4 as packages to be installed to ubuntu 16.04, with the following reasons:

- iriclib need fortran compiler to build.
- m4 is needed to compile netcdf.
